### PR TITLE
Validate signature against the KID declared in COSE header

### DIFF
--- a/src/certificate.js
+++ b/src/certificate.js
@@ -3,6 +3,7 @@ const { CertificateParsingError } = require('./errors');
 
 const dccToModel = (dcc) => {
   const { payload } = dcc;
+  const { kid } = dcc;
   const dateOfBirth = payload.dob;
 
   const person = {
@@ -81,6 +82,7 @@ const dccToModel = (dcc) => {
     tests,
     recoveryStatements,
     dcc,
+    kid,
   };
 };
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -340,18 +340,14 @@ async function checkSignature(certificate) {
   const signaturesList = cache.getSignatureList();
   const signatures = cache.getSignatures();
   let verified = false;
-  for (const key of signaturesList) {
-    if (signatures[key]) {
-      try {
-        verified = await certificate.dcc.checkSignatureWithCertificate(signatures[key]);
-        if (verified) {
-          break;
-        }
-      } catch (err) {
-        continue;
-      }
+  if (certificate.kid && signaturesList.includes(certificate.kid)) {
+    try {
+      verified = await certificate.dcc.checkSignatureWithCertificate(signatures[certificate.kid]);
+    } catch (err) {
+      return false;
     }
   }
+
   return !!verified;
 }
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -344,7 +344,7 @@ async function checkSignature(certificate) {
     try {
       verified = await certificate.dcc.checkSignatureWithCertificate(signatures[certificate.kid]);
     } catch (err) {
-      return false;
+      // invalid signature or key, return false
     }
   }
 


### PR DESCRIPTION
At the moment, the SDK checks the DGC signature against all the valid certificates, regardless the KID specified in the COSE header.

This PR changes this behavior and checks the signature like the "official" Android SDK:

https://github.com/ministero-salute/it-dgc-verificac19-sdk-android/blob/17d3b28f8caeb2de6cf08bf094b964caf097f8ae/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/model/VerificationViewModel.kt#L178-L184