### PR TITLE
MongoDB takes too long to delete old revoked uvci

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -16,7 +16,7 @@ const SIGNATURES_FILE_PATH = path.join(CACHE_FOLDER, SIGNATURES_FILE);
 const RULES_FILE_PATH = path.join(CACHE_FOLDER, RULES_FILE);
 const SIGNATURES_LIST_FILE_PATH = path.join(CACHE_FOLDER, SIGNATURES_LIST_FILE);
 
-const UPDATE_WINDOW_HOURS = 24;
+const UPDATE_WINDOW_HOURS = Number.parseInt(process.env.VC19_UPDATE_HOURS || '24', 10);
 
 class Cache {
   async setUp(crlManager = crl) {

--- a/src/crl.js
+++ b/src/crl.js
@@ -13,28 +13,45 @@ class CRL {
   }
 
   async storeRevokedUVCI(revokedUvci = [], deletedRevokedUvci = []) {
+    deletedRevokedUvci.length > 50000 ?
+      await this.clean().then(() => this.#insertRevokedUvci(revokedUvci)) :
+      await this.#insertRevokedUvci(revokedUvci).then(() => this.#deleteRevokedUvci(deletedRevokedUvci))
+  }
+
+  async #insertRevokedUvci(revokedUvci = []) {
     if (revokedUvci.length > 0) {
       try {
-        await this._dbModel.insertMany(revokedUvci.map((uvci) => ({ _id: uvci })));
+        await this._dbModel.insertMany(revokedUvci.map((uvci) => ({
+          _id: uvci
+        })));
       } catch {
         for (const uvciToInsert of revokedUvci) {
           try {
-            await new this._dbModel({ _id: uvciToInsert }).save();
+            await new this._dbModel({
+              _id: uvciToInsert
+            }).save();
           } catch {
             // Insertion error (duplicate)
           }
         }
       }
     }
+  }
+
+  async #deleteRevokedUvci(deletedRevokedUvci = []) {
     if (deletedRevokedUvci.length > 0) {
       for (const uvciToRemove of deletedRevokedUvci) {
-        await this._dbModel.deleteOne({ _id: uvciToRemove });
+        await this._dbModel.deleteOne({
+          _id: uvciToRemove
+        });
       }
     }
   }
 
   async isUVCIRevoked(uvci) {
-    return !!await this._dbModel.findOne({ _id: uvci });
+    return !!await this._dbModel.findOne({
+      _id: uvci
+    });
   }
 
   async tearDown() {

--- a/src/crl.js
+++ b/src/crl.js
@@ -13,7 +13,11 @@ class CRL {
   }
 
   async storeRevokedUVCI(revokedUvci = [], deletedRevokedUvci = []) {
-    deletedRevokedUvci.length > 50000 ?
+
+    let env = process.env.VC19_MONGODB_CLEAN_THRESHOLD || '50000'
+    let threshold = parseInt(env, 10);
+
+    deletedRevokedUvci.length > threshold ?
       await this.clean().then(() => this.#insertRevokedUvci(revokedUvci)) :
       await this.#insertRevokedUvci(revokedUvci).then(() => this.#deleteRevokedUvci(deletedRevokedUvci))
   }

--- a/src/crl.js
+++ b/src/crl.js
@@ -35,7 +35,7 @@ class CRL {
 
     async function deleteUvci(db) {
       if (deletedRevokedUvci.length > 0) {
-        await db.deleteMany({ id: { $in: deletedRevokedUvci } });
+        await db.deleteMany({ _id: { $in: deletedRevokedUvci } });
       }
     }
 

--- a/src/service.js
+++ b/src/service.js
@@ -57,6 +57,7 @@ const updateCRL = async () => {
       } else {
         break;
       }
+    // eslint-disable-next-line no-constant-condition
     } while (true);
   }
 };


### PR DESCRIPTION
When the revoked certificates are too many (> 50000) MongoDB takes too long to delete the certificates (+ 2h), I found it more efficient to completely delete the database and download the new certificates instead of deleting them one by one, the clean up threshold can be set using the env variable `VC19_MONGODB_CLEAN_THRESHOLD` (default 50000).