### PR TITLE
feat: add validator type dpcm4feb

### DIFF
--- a/types/validator.d.ts
+++ b/types/validator.d.ts
@@ -1,4 +1,4 @@
-import { RulesResult, DCCCertificate, ValidateGP } from "./models";
+import { DCCCertificate, RulesResult, ValidateGP } from "./models";
 
 declare module Validator {
   function checkSignature(certificate: DCCCertificate): Promise<boolean>;
@@ -16,10 +16,14 @@ declare module Validator {
   }
 
   enum mode {
-    SUPER_DGP = '2G',
-    NORMAL_DGP = '3G',
-    BOOSTER_DGP = 'BOOSTER'
+    SUPER_DGP = "2G",
+    NORMAL_DGP = "3G",
+    BOOSTER_DGP = "BOOSTER",
+    VISITORS_RSA_DGP = BOOSTER_DGP,
+    WORK_DGP = "WORK",
+    ENTRY_IT_DGP = "ENTRY_IT",
   }
 }
 
-export { Validator }
+export { Validator };
+


### PR DESCRIPTION
I'm using this in a TS project and I need the enum for the validator to match the options in  `validator.js`