### PR TITLE
[#36] fix - bug TEST_NEEDED on newer three doses qr

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -168,10 +168,10 @@ const checkVaccinations = (certificate, rules, mode) => {
       vaccinationStatus = VACCINATION_STATUS.COMPLETE;
       // Check if Booster
       if (type === JOHNSON) {
-        if (last.doseNumber > last.totalSeriesOfDoses && last.doseNumber >= 2) {
+        if (last.doseNumber >= last.totalSeriesOfDoses && last.doseNumber >= 2) {
           vaccinationStatus = VACCINATION_STATUS.BOOSTER;
         }
-      } else if (last.doseNumber > last.totalSeriesOfDoses && last.doseNumber >= 3) {
+      } else if (last.doseNumber >= last.totalSeriesOfDoses && last.doseNumber >= 3) {
         vaccinationStatus = VACCINATION_STATUS.BOOSTER;
       }
     }


### PR DESCRIPTION
## Description
As already mentioned in #36, this PR tackles:
* bug TEST_NEEDED on newer three doses qr

Trying to validate several third doses Moderna Green Pass Certificates with VISITORS_RSA scan mode, the validate function returns TEST_NEEDED uncorrectly.
Doing some reverse engineering, we've found that third doses Green Pass Certificates are uncorrectly defined with `validationStatus = complete`, which represent just a complete cycle Green Pass Certificate (two doses or one dose for Johnson&Johnson), instead of a `validationStatus = booster` (check code at `line 168` of `validator.js`).

This issue happens because of a bad comparison of `last.doseNumber > last.totalSeriesOfDoses`. My personal Green Pass certificate (three doses) and some others have `doseNumber = 3` and `totalSeriesOfDoses = 3`, in this situation, the condition will be always false and all the newer Green Pass Certificates with `totalSeriesOfDoses = 3` will fail the validation.