### PR TITLE
Fix sul controllo delle dosi

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -168,7 +168,7 @@ const checkVaccinations = (certificate, rules, mode) => {
         if (last.doseNumber >= last.totalSeriesOfDoses && last.doseNumber >= 2) {
           vaccinationStatus = VACCINATION_STATUS.BOOSTER;
         }
-      } else if (last.doseNumber >= last.totalSeriesOfDoses && last.doseNumber >= 3) {
+      } else if (last.doseNumber >= last.totalSeriesOfDoses || last.doseNumber >= 3) {
         vaccinationStatus = VACCINATION_STATUS.BOOSTER;
       }
     }

--- a/src/validator.js
+++ b/src/validator.js
@@ -165,10 +165,10 @@ const checkVaccinations = (certificate, rules, mode) => {
       vaccinationStatus = VACCINATION_STATUS.COMPLETE;
       // Check if Booster
       if (type === JOHNSON) {
-        if (last.doseNumber >= last.totalSeriesOfDoses && last.doseNumber >= 2) {
+        if (last.doseNumber >= 2) {
           vaccinationStatus = VACCINATION_STATUS.BOOSTER;
         }
-      } else if (last.doseNumber >= last.totalSeriesOfDoses || last.doseNumber >= 3) {
+      } else if (last.doseNumber > last.totalSeriesOfDoses || last.doseNumber >= 3) {
         vaccinationStatus = VACCINATION_STATUS.BOOSTER;
       }
     }

--- a/test/verification.test.js
+++ b/test/verification.test.js
@@ -263,7 +263,7 @@ describe('Testing integration between Certificate and Validator', () => {
       '^Doses 2/2 - Vaccination is not valid yet, .*$',
     );
     // Doses 2/2 expired
-    mockdate.set('2022-06-17T00:00:00.000Z');
+    mockdate.set('2023-06-17T00:00:00.000Z');
     await verifyRulesFromImage(
       path.join('test', 'data', 'eu_test_certificates', 'SK_4.png'), false,
       Validator.codes.NOT_VALID,


### PR DESCRIPTION
Allineato il controllo delle dosi come nell'Android SDK
https://github.com/ministero-salute/it-dgc-verificac19-sdk-android/blob/develop/sdk/src/main/java/it/ministerodellasalute/verificaC19sdk/model/CertificateModel.kt#L97